### PR TITLE
Fix multiline parsing

### DIFF
--- a/src/vcard.js
+++ b/src/vcard.js
@@ -24,11 +24,7 @@
             if (lines[i].toUpperCase() == PREFIX || lines[i].toUpperCase() == POSTFIX) {
                 continue;
             }
-            pieces = lines[i].split(':');
-            key = pieces.shift();
-            value = pieces.join(':');
-            namespace = false;
-            meta = {};
+            var data = lines[i];
 
             /**
              * Check that next line continues current
@@ -42,10 +38,16 @@
             // next line should start with space or tab character
             if (isValueContinued(i)) {
                 while (isValueContinued(i)) {
-                    value += lines[i + 1].trim();
+                    data += lines[i + 1].trim();
                     i++;
                 }
             }
+
+            pieces = data.split(':');
+            key = pieces.shift();
+            value = pieces.join(':');
+            namespace = false;
+            meta = {};
 
             // meta fields in property
             if (key.match(/;/)) {

--- a/test/vcard.parse.spec.js
+++ b/test/vcard.parse.spec.js
@@ -139,4 +139,12 @@ describe('vCard.parse', function () {
 
         expect(card['photo']).toEqual( [ { value : '', meta : { 'x-abcrop-rectangle' : [ 'ABClipRect_1&0&0&671&671&Nh68TCRv7GErj8P8mk8qCA' ] } } ]);
     });
+
+    it('Should properly parse multi line PHOTO properties', function () {
+        var raw = 'PHOTO;X-ABCROP-RECTANGLE=ABClipRect_1&0&0&671&671&Nh68TCRv7GErj8P8mk8qCA==;\n' +
+        ' ENCODING=b;TYPE=JPEG:/9j/4AAQSkZJRgABAQEASABIAAD/4QBARXhpZgAATU0AKgAAAAgAA',
+            card = vCard.parse(raw);
+
+        expect(card['photo']).toEqual( [ { value : '/9j/4AAQSkZJRgABAQEASABIAAD/4QBARXhpZgAATU0AKgAAAAgAA', meta : { encoding: ['b'], type: ['JPEG'], 'x-abcrop-rectangle' : [ 'ABClipRect_1&0&0&671&671&Nh68TCRv7GErj8P8mk8qCA' ] } } ]);
+    });
 });


### PR DESCRIPTION

Just another parsing issue with:

````
PHOTO;X-ABCROP-RECTANGLE=ABClipRect_1&0&0&671&671&Nh68TCRv7GErj8P8mk8qCA==;
 ENCODING=b;TYPE=JPEG:/9j/4AAQSkZJRgABAQEASABIAAD/4QBARXhpZgAATU0AKgAAAAgAA
