### PR TITLE
Array values have been manipulated by the generate function

### DIFF
--- a/src/vcard.js
+++ b/src/vcard.js
@@ -215,10 +215,9 @@
                     line += escapeCharacters(value.value);
                 } else {
                     // complex values
-                    value.value = value.value.map(function (item) {
+                    line += value.value.map(function (item) {
                         return escapeCharacters(item);
-                    });
-                    line += value.value.join(';');
+                    }).join(';');
                 }
 
                 // line-length limit. Content lines

--- a/test/vcard.generate.spec.js
+++ b/test/vcard.generate.spec.js
@@ -302,4 +302,31 @@ describe('vCard.generate', function () {
             POSTFIX
         ].join('\r\n'));
     });
+
+    it('Should not change my data', function () {
+        var card = {
+            adr: [
+                {value: ['A', '1,2', 'b']  }
+            ],
+            nickname: [
+                {value: 'Mouse,Mikey'  }
+            ]
+        };
+        var string = vCard.generate(card);
+
+        expect(string).toEqual([
+            PREFIX,
+            'ADR:A;1\\,2;b',
+            'NICKNAME:Mouse\\,Mikey',
+            POSTFIX
+        ].join('\r\n'));
+        expect(card).toEqual({
+            adr:[
+                {value: ['A', '1,2', 'b']}
+            ],
+            nickname: [
+                {value: 'Mouse,Mikey'  }
+            ]
+        });
+    });
 });


### PR DESCRIPTION
Within the ownCloud contacts app we have the issue that consecutive save operations added more and more backslashes 