### PR TITLE
Always include FN field in generated vCard, even if empty

### DIFF
--- a/src/vcard.js
+++ b/src/vcard.js
@@ -167,6 +167,8 @@
 
     var COMMA_SEPARATED_FIELDS = ['nickname', 'related', 'categories', 'pid'];
 
+    var REQUIRED_FIELDS = ['fn'];
+
     /**
      * Generate vCard representation af object
      * @param {*} data
@@ -208,10 +210,16 @@
                 return;
             }
             data[key].forEach(function (value) {
-                // ignore empty values
-                if (typeof value.value === 'undefined' || value.value == '') {
+                // ignore undefined values
+                if (typeof value.value === 'undefined') {
                     return;
                 }
+
+                // ignore empty values (unless it's a required field)
+                if (value.value == '' && REQUIRED_FIELDS.indexOf(key) === -1) {
+                    return;
+                }
+
                 // ignore empty array values
                 if (value.value instanceof Array) {
                     var empty = true;

--- a/test/vcard.generate.spec.js
+++ b/test/vcard.generate.spec.js
@@ -182,9 +182,9 @@ describe('vCard.generate', function () {
         ].join('\r\n'));
     });
 
-    it('Should ignore properties with empty string values', function () {
+    it('Should ignore non-required properties with empty string values', function () {
         var card = {
-            fn: [
+            url: [
                 {value: ''}
             ]
         };
@@ -192,6 +192,21 @@ describe('vCard.generate', function () {
 
         expect(string).toEqual([
             PREFIX,
+            POSTFIX
+        ].join('\r\n'));
+    });
+
+    it('Should NOT ignore FN with empty string value', function () {
+        var card = {
+            fn: [
+                { value: '' }
+            ]
+        };
+        var string = vCard.generate(card);
+
+        expect(string).toEqual([
+            PREFIX,
+            'FN:',
             POSTFIX
         ].join('\r\n'));
     });

--- a/test/vcard.parse.spec.js
+++ b/test/vcard.parse.spec.js
@@ -165,4 +165,11 @@ describe('vCard.parse', function () {
             { value: ['Jim', 'Jimmie'] }
         ]);
     });
+
+    it('Should parse vcard with empty first name', function () {
+        var raw = 'FN:',
+            card = vCard.parse(raw);
+
+        expect(card.fn).toEqual([{value: ''}]);
+    });
 });


### PR DESCRIPTION
According to the specification
( https://tools.ietf.org/html/rfc6350#section-6.2.1 ),
FN is a required field.

Generating a vCard without an FN field could lead to the other
side rejecting it as invalid.

This is the case with Nextcloud Contacts' import service
and causes problems like nextcloud/contacts#413
( https://github.com/nextcloud/contacts/issues/413 ).
Nextcloud Contacts makes use of this library to preprocess
`.vcf` files. Parsing entries with empty FN values is handled well
by this library. But as later on, new vCard entries are
generated (`vCard.generate()`) out of that data,
which completely lack an FN field.
Those FN-field-lacking vCards then reach the PHP server, which
chokes on them, as they are indeed invalid according to the specs.

This patch ensures that FN is always included in generated vCards,
even if the FN input is an empty string.

An FN value of `undefined` still yields vCards without an FN field.
That code remains unchanged. How it should be handled is a separate
issue.